### PR TITLE
Update to enable saving/loading model as .json

### DIFF
--- a/ats/core/ats_layer.py
+++ b/ats/core/ats_layer.py
@@ -90,6 +90,10 @@ class SamplePatches(Layer):
 
         return [patches, sampled_attention]
 
+    def get_config(self):
+        return {"n_patches": self._n_patches, "patch_size": self._patch_size,
+                "receptive_field": self._receptive_field, "replace": self._replace, "use_logits": self._use_logits}
+
 
 class Expectation(Layer):
     """Expectation averages the features in a way that gradients can be
@@ -116,6 +120,9 @@ class Expectation(Layer):
             features,
             replace=self._replace
         )
+
+    def get_config(self):
+        return {"replace": self._replace}
 
 
 def attention_sampling(attention, feature, patch_size=None, n_patches=10,


### PR DESCRIPTION
I had an issue getting reproducible results just saving the weights of the model and loading them into the redefined model.
By saving the model itself as a .json file and saving the model's weights using Keras' builtin ModelCheckpoint callback by:

```
model_json = model.to_json()
with open(os.path.join(args["datapath"], "model.json"), "w") as json_file:
    json_file.write(model_json)
```

And afterwards loading the model from a .json file and loading the weights into that model by:

```
json_file = open(os.path.join(args["datapath"], "model.json"), "r")
loaded_model_json = json_file.read()
json_file.close()
model = model_from_json(loaded_model_json, {"ResizeImages": ResizeImages, "SampleSoftmax": SampleSoftmax, 
"L2Normalize": L2Normalize, "ActivityRegularizer": ActivityRegularizer,  
"SamplePatches": SamplePatches, "TotalReshape": TotalReshape, "Expectation": Expectation})

model.load_weights(args["weights_path"])
```

This allowed me to get reproducible results after saving/loading the model and the weights. The changes made to ats_layer.py and layers.py allow this way of saving and loading.